### PR TITLE
Explicitly create user-specific snmp.conf to load MIBs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,11 @@ before_install:
   # Start up SNMPD with our test config
   - snmpd -c tests/snmpd.conf
 
+  # Ensure that all mibs are loaded by the SNMP client/client library
+  # SNMP will prefer $HOME/.snmp/snmp.conf over /usr/local/etc/snmp.conf
+  - mkdir -m 0755 ~/.snmp
+  - echo 'mibs +ALL' > ~/.snmp/snmp.conf
+
 install:
   # Install the Coveralls library
   - pip install coveralls

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [pytest]
 addopts = -s --cov=easysnmp --cov-report=term-missing --flake8
+
+[flake8]
+exclude = .svn,CVS,.bzr,.hg,.git,__pycache__,build


### PR DESCRIPTION
It isn't required, but should anyone reference the travis file to determine how to run the tests, it is one less error that they might make because Ubuntu doesn't load all MIBs due to licensing reasons.