### PR TITLE
Fix types + throw correct exception for NoSuchName (in SNMP v1)

### DIFF
--- a/easysnmp/exceptions.py
+++ b/easysnmp/exceptions.py
@@ -17,6 +17,13 @@ class EasySNMPUnknownObjectIDError(EasySNMPError):
     """Raised when an inexisted OID is requested"""
 
 
+class EasySNMPNoSuchNameError(EasySNMPError):
+    """
+    Raised when an OID is requested which may be an invalid object name
+    or invalid instance (only applies to SNMPv1).
+    """
+
+
 class EasySNMPNoSuchObjectError(EasySNMPError):
     """
     Raised when an OID is requested which may have some form of existence but

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -2146,16 +2146,20 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
                                                        vars->name_length);
                 str_buf[sizeof(str_buf) - 1] = '\0';
 
+                type = __translate_asn_type(vars->type);
+
                 if (__is_leaf(tp))
                 {
-                    type = (tp->type ? tp->type : tp->parent->type);
                     getlabel_flag &= ~NON_LEAF_NAME;
+                    py_log_msg(DEBUG, "netsnmp_getnext: is_leaf: %d", tp->type);
                 }
                 else
                 {
                     getlabel_flag |= NON_LEAF_NAME;
-                    type = __translate_asn_type(vars->type);
+                    py_log_msg(DEBUG, "netsnmp_getnext: !is_leaf: %d", tp->type);
                 }
+
+                py_log_msg(DEBUG, "netsnmp_getnext: str_buf: %s", str_buf);
 
                 __get_label_iid((char *) str_buf, &tag, &iid, getlabel_flag);
 
@@ -2517,16 +2521,20 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                                                                vars->name_length);
                         str_buf[sizeof(str_buf) - 1] = '\0';
 
+                        type = __translate_asn_type(vars->type);
+
                         if (__is_leaf(tp))
                         {
-                            type = (tp->type ? tp->type : tp->parent->type);
                             getlabel_flag &= ~NON_LEAF_NAME;
+                            py_log_msg(DEBUG, "netsnmp_walk: is_leaf: %d", tp->type);
                         }
                         else
                         {
                             getlabel_flag |= NON_LEAF_NAME;
-                            type = __translate_asn_type(vars->type);
+                            py_log_msg(DEBUG, "netsnmp_walk: !is_leaf: %d", tp->type);
                         }
+
+                        py_log_msg(DEBUG, "netsnmp_walk: str_buf: %s", str_buf);
 
                         __get_label_iid((char *) str_buf, &tag, &iid,
                                         getlabel_flag);
@@ -2812,16 +2820,22 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
                                                                vars->name,
                                                                vars->name_length);
                         str_buf[sizeof(str_buf) - 1] = '\0';
+
+                        type = __translate_asn_type(vars->type);
+
                         if (__is_leaf(tp))
                         {
-                            type = (tp->type ? tp->type : tp->parent->type);
                             getlabel_flag &= ~NON_LEAF_NAME;
+                            py_log_msg(DEBUG, "netsnmp_getbulk: is_leaf: %d", tp->type);
                         }
                         else
                         {
                             getlabel_flag |= NON_LEAF_NAME;
-                            type = __translate_asn_type(vars->type);
+                            py_log_msg(DEBUG, "netsnmp_getbulk: !is_leaf: %d", tp->type);
                         }
+
+                        py_log_msg(DEBUG, "netsnmp_getbulk: str_buf: %s", str_buf);
+
 
                         __get_label_iid((char *) str_buf, &tag, &iid,
                                         getlabel_flag);

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,15 @@ from setuptools.command.test import test as TestCommand
 
 # Determine if a base directory has been provided with the --basedir option
 in_tree = False
+# Add compiler flags if debug is set
+compile_args = []
 for arg in sys.argv:
-    if arg.startswith('--basedir='):
+    if arg.startswith('--debug'):
+        # Note from GCC manual:
+        #       If you use multiple -O options, with or without level numbers,
+        #       the last such option is the one that is effective.
+        compile_args.extend('-Wall -O0 -g'.split())
+    elif arg.startswith('--basedir='):
         basedir = arg.split('=')[1]
         sys.argv.remove(arg)
         in_tree = True
@@ -79,7 +86,8 @@ setup(
     ext_modules=[
         Extension(
             'easysnmp.interface', ['easysnmp/interface.c'],
-            library_dirs=libdirs, include_dirs=incdirs, libraries=libs
+            library_dirs=libdirs, include_dirs=incdirs, libraries=libs,
+            extra_compile_args=compile_args
         )
     ],
     classifiers=[


### PR DESCRIPTION
Here are some simple tests against the code that I'm committing:

```python
from pprint import pprint
import easysnmp

sess_args = {'community': 'public', 'hostname': 'localhost', 'remote_port': 11161, 'version': 1, 'retries': 5}

s = easysnmp.Session(retry_no_such=True, **sess_args)

def fetch(s, oids):
      print "# fetching: {}".format(oids)
      v = s.get(oids)
      pprint(v)


fetch(s, ['iso'])
fetch(s, ['iso', 'iso'])
fetch(s, ['.1.3.6.1.2.1.1.1.0', 'iso'])
fetch(s, ['.1.3.6.1.2.1.1.1.0', 'iso', 'iso', 'iso', 'iso', '.1.3.6.1.2.1.1.1.0', 'iso'])


s = easysnmp.Session(retry_no_such=False, **sess_args)
fetch(s, ['.1.3.6.1.2.1.1.1.0', 'iso'])
```

Which outputs:
```bash
$ python t.py
# fetching: ['iso']
[<SNMPVariable value='' (oid='ccitt.1', oid_index='', snmp_type='NULL')>]
# fetching: ['iso', 'iso']
[<SNMPVariable value='' (oid='ccitt.1', oid_index='', snmp_type='NULL')>,
 <SNMPVariable value=None (oid='iso', oid_index='', snmp_type=None)>]
# fetching: ['.1.3.6.1.2.1.1.1.0', 'iso']
[<SNMPVariable value='Linux nsda3bpldv40 3.13.0-54-generic #91-Ubuntu SMP Tue May 26 19:15:08 UTC 2015 x86_64' (oid='sysDescr', oid_index='0', snmp_type='OCTETSTR')>,
 <SNMPVariable value=None (oid='iso', oid_index='', snmp_type=None)>]
# fetching: ['.1.3.6.1.2.1.1.1.0', 'iso', 'iso', 'iso', 'iso', '.1.3.6.1.2.1.1.1.0', 'iso']
[<SNMPVariable value='Linux nsda3bpldv40 3.13.0-54-generic #91-Ubuntu SMP Tue May 26 19:15:08 UTC 2015 x86_64' (oid='sysDescr', oid_index='0', snmp_type='OCTETSTR')>,
 <SNMPVariable value='Linux nsda3bpldv40 3.13.0-54-generic #91-Ubuntu SMP Tue May 26 19:15:08 UTC 2015 x86_64' (oid='sysDescr', oid_index='0', snmp_type='OCTETSTR')>,
 <SNMPVariable value=None (oid='iso', oid_index='', snmp_type=None)>,
 <SNMPVariable value=None (oid='iso', oid_index='', snmp_type=None)>,
 <SNMPVariable value=None (oid='iso', oid_index='', snmp_type=None)>,
 <SNMPVariable value=None (oid='.1.3.6.1.2.1.1.1.0', oid_index='', snmp_type=None)>,
 <SNMPVariable value=None (oid='iso', oid_index='', snmp_type=None)>]
# fetching: ['.1.3.6.1.2.1.1.1.0', 'iso']
Traceback (most recent call last):
  File "t.py", line 21, in <module>
    fetch(s, ['.1.3.6.1.2.1.1.1.0', 'iso'])
  File "t.py", line 10, in fetch
    v = s.get(oids)
  File "/home/d752823/easysnmp/build/lib.linux-x86_64-2.7/easysnmp/session.py", line 315, in get
    interface.get(self, varlist)
