### PR TITLE
SNMP v1 fixes for NoSuchName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 
 # Documentation builds
 docs/_build/
+
+# vim stuff
+.ropeproject

--- a/easysnmp/exceptions.py
+++ b/easysnmp/exceptions.py
@@ -17,6 +17,13 @@ class EasySNMPUnknownObjectIDError(EasySNMPError):
     """Raised when an inexisted OID is requested"""
 
 
+class EasySNMPNoSuchNameError(EasySNMPError):
+    """
+    Raised when an OID is requested which may be an invalid object name
+    or invalid instance (only applies to SNMPv1).
+    """
+
+
 class EasySNMPNoSuchObjectError(EasySNMPError):
     """
     Raised when an OID is requested which may have some form of existence but

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -2146,16 +2146,20 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
                                                        vars->name_length);
                 str_buf[sizeof(str_buf) - 1] = '\0';
 
+                type = __translate_asn_type(vars->type);
+
                 if (__is_leaf(tp))
                 {
-                    type = (tp->type ? tp->type : tp->parent->type);
                     getlabel_flag &= ~NON_LEAF_NAME;
+                    py_log_msg(DEBUG, "netsnmp_getnext: is_leaf: %d", tp->type);
                 }
                 else
                 {
                     getlabel_flag |= NON_LEAF_NAME;
-                    type = __translate_asn_type(vars->type);
+                    py_log_msg(DEBUG, "netsnmp_getnext: !is_leaf: %d", tp->type);
                 }
+
+                py_log_msg(DEBUG, "netsnmp_getnext: str_buf: %s", str_buf);
 
                 __get_label_iid((char *) str_buf, &tag, &iid, getlabel_flag);
 
@@ -2517,16 +2521,20 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                                                                vars->name_length);
                         str_buf[sizeof(str_buf) - 1] = '\0';
 
+                        type = __translate_asn_type(vars->type);
+
                         if (__is_leaf(tp))
                         {
-                            type = (tp->type ? tp->type : tp->parent->type);
                             getlabel_flag &= ~NON_LEAF_NAME;
+                            py_log_msg(DEBUG, "netsnmp_walk: is_leaf: %d", tp->type);
                         }
                         else
                         {
                             getlabel_flag |= NON_LEAF_NAME;
-                            type = __translate_asn_type(vars->type);
+                            py_log_msg(DEBUG, "netsnmp_walk: !is_leaf: %d", tp->type);
                         }
+
+                        py_log_msg(DEBUG, "netsnmp_walk: str_buf: %s", str_buf);
 
                         __get_label_iid((char *) str_buf, &tag, &iid,
                                         getlabel_flag);
@@ -2812,16 +2820,22 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
                                                                vars->name,
                                                                vars->name_length);
                         str_buf[sizeof(str_buf) - 1] = '\0';
+
+                        type = __translate_asn_type(vars->type);
+
                         if (__is_leaf(tp))
                         {
-                            type = (tp->type ? tp->type : tp->parent->type);
                             getlabel_flag &= ~NON_LEAF_NAME;
+                            py_log_msg(DEBUG, "netsnmp_getbulk: is_leaf: %d", tp->type);
                         }
                         else
                         {
                             getlabel_flag |= NON_LEAF_NAME;
-                            type = __translate_asn_type(vars->type);
+                            py_log_msg(DEBUG, "netsnmp_getbulk: !is_leaf: %d", tp->type);
                         }
+
+                        py_log_msg(DEBUG, "netsnmp_getbulk: str_buf: %s", str_buf);
+
 
                         __get_label_iid((char *) str_buf, &tag, &iid,
                                         getlabel_flag);

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -27,6 +27,18 @@ typedef int Py_ssize_t;
 #include <regex.h>
 #endif
 
+/* include bitarray data structure for v1 queries */
+#include "simple_bitarray.h"
+
+/*
+ * In snmpv1 when using retry_nosuch we need to track the
+ * index of each bad OID in the responses using a bitarray;
+ * DEFAULT_NUM_BAD_OIDS is a tradeoff to avoid allocating
+ * heavily on the heap; if we need to track more, we can
+ * just malloc on the heap.
+ */
+#define DEFAULT_NUM_BAD_OIDS (sizeof(bitarray_word) * 8 * 3)
+
 #define STRLEN(x) ((x) ? strlen((x)) : 0)
 
 #define SUCCESS (1)
@@ -1034,11 +1046,16 @@ OCT:
 /* the input 'pdu' argument will be freed */
 static int __send_sync_pdu(netsnmp_session *ss, netsnmp_pdu *pdu,
                            netsnmp_pdu **response, int retry_nosuch,
-                           char *err_str, int *err_num, int *err_ind)
+                           char *err_str, int *err_num, int *err_ind,
+                           bitarray *invalid_oids)
 {
     int status = 0;
     long command = pdu->command;
     char *tmp_err_str;
+    size_t retry_num = 0;
+
+    /* Note: SNMP uses 1-based indexing with OIDs, so 0 is unused */
+    unsigned long last_errindex = 0;
 
     *err_num = 0;
     *err_ind = 0;
@@ -1090,6 +1107,39 @@ retry:
                     if (retry_nosuch)
                     {
                         /*
+                         * When using retry, we expect the agent to behave
+                         * in two ways:
+                         *
+                         *  (1) provide error index in descending order (easy case)
+                         *  (2) provide error index in ascending order (hard case)
+                         *
+                         *  The reason (2) is hard, is because everytime an OID
+                         *  is elided in the request PDU, we need to compensate.
+                         *
+                         *  It is possible that the agent may perform pathologically
+                         *  in which case we provide no guarantees whatsoever.
+                         */
+
+                        if (!last_errindex)
+                        {
+                            /* we haven't seen an errindex yet */
+                            bitarray_set_bit(invalid_oids, (*response)->errindex - 1);
+                        }
+                        else if (last_errindex > (*response)->errindex)
+                        {
+                            /* case (1) where error index is in descending order */
+                            bitarray_set_bit(invalid_oids, (*response)->errindex - 1);
+                        }
+                        else
+                        {
+                            /* case (2) where error index is in ascending order */
+                            bitarray_set_bit(invalid_oids, (*response)->errindex - 1 + retry_num);
+                        }
+
+                        /* finally we update the last_errindex for the next retry */
+                        last_errindex = (*response)->errindex;
+
+                        /*
                          * fix the GET REQUEST message using snmp_fix_pdu
                          * which elidse variable which return NOSUCHNAME error,
                          * until there is either a successful response
@@ -1113,6 +1163,7 @@ retry:
                             snmp_free_pdu(*response);
                         }
 
+                        retry_num++;
                         goto retry;
                     }
                     else /* !retry_nosuch */
@@ -1782,6 +1833,10 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
     char *tmpstr;
     Py_ssize_t tmplen;
     int error = 0;
+    unsigned long snmp_version = 0;
+
+    BITARRAY_DECLARE(snmpv1_invalid_oids, DEFAULT_NUM_BAD_OIDS);
+    bitarray *invalid_oids = snmpv1_invalid_oids;
 
     oid_arr = calloc(MAX_OID_LEN, sizeof(oid));
 
@@ -1793,6 +1848,8 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
         }
 
         ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+
+        snmp_version = py_netsnmp_attr_long(session, "version");
 
         if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
         {
@@ -1866,8 +1923,24 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
             }
         }
 
+        /* if we cannot represent the number of bad oids, we will need to resize. */
+        if (snmp_version == 1 && DEFAULT_NUM_BAD_OIDS < varlist_len)
+        {
+            invalid_oids = bitarray_calloc(varlist_len);
+
+            if (!invalid_oids)
+            {
+                error = 1;
+                snmp_free_pdu(pdu);
+                const char *err_msg = "failed to call bitarray_calloc";
+                PyErr_SetString(PyExc_RuntimeError, err_msg);
+                goto done;
+            }
+        }
+
         status = __send_sync_pdu(ss, pdu, &response, retry_nosuch, err_str,
-                                 &err_num, &err_ind);
+                                 &err_num, &err_ind, invalid_oids);
+
         __py_netsnmp_update_session_errors(session, err_str, err_num, err_ind);
         if (status != 0)
         {
@@ -1892,10 +1965,12 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
                                NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
                                NETSNMP_OID_OUTPUT_FULL);
         }
-        /* Setting use_numeric forces use_long_names on so check for
-          use_numeric after use_long_names (above) to make sure the final
-          outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
-          NETSNMP_OID_OUTPUT_NUMERIC */
+        /*
+         * Setting use_numeric forces use_long_names on so check for
+         * use_numeric after use_long_names (above) to make sure the final
+         * outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
+         * NETSNMP_OID_OUTPUT_NUMERIC
+         */
         if (py_netsnmp_attr_long(session, "use_numeric"))
         {
             getlabel_flag |= USE_LONG_NAMES;
@@ -1906,13 +1981,42 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
                                NETSNMP_OID_OUTPUT_NUMERIC);
         }
 
-        for (vars = (response ? response->variables : NULL), varlist_ind = 0;
-             vars && (varlist_ind < varlist_len);
-             vars = vars->next_variable, varlist_ind++)
+        /*
+         * In SNMPv1 we go through the response variables only if we know
+         * the varlist_ind is not set in the invalid_oids bit array.
+         * For bits that are set, we fix the input varbind so that it
+         * indicates NOSUCHNAME. For bits that are not set, we fill in the
+         * corresponding varbind and advance.
+         *
+         * In SNMPv2/v3 we simply fill the response variables against the
+         * original input Varbind list.
+         */
+        vars = (response ? response->variables : NULL);
+
+        for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
         {
+            int no_such_name = 0;
+
+            if (snmp_version == 1)
+            {
+                /* check if oid is invalid */
+                if (bitarray_test_bit(invalid_oids, varlist_ind))
+                {
+                    no_such_name = 1;
+                }
+            }
+            else if (!vars)
+            {
+                /*
+                 * no more varbinds to inspect
+                 * (this will only happen if no response is received from SNMP.
+                 */
+                break;
+            }
+
             varbind = PySequence_GetItem(varlist, varlist_ind);
 
-            if (PyObject_HasAttrString(varbind, "oid"))
+            if (!no_such_name && PyObject_HasAttrString(varbind, "oid"))
             {
                 *str_buf = '.';
                 *(str_buf + 1) = '\0';
@@ -1961,11 +2065,37 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
 
                 Py_DECREF(varbind);
             }
+            else if (no_such_name)
+            {
+                if (!PyObject_HasAttrString(varbind, "oid"))
+                {
+                    py_log_msg(DEBUG, "netsnmp_get: bad varbind (%d)",
+                               varlist_ind);
+                    Py_XDECREF(varbind);
+                }
+
+                py_netsnmp_attr_set_string(varbind, "snmp_type", "NOSUCHNAME",
+                                           strlen("NOSUCHNAME"));
+
+                py_netsnmp_attr_set_string(varbind, "value",
+                                           "NOSUCHNAME", strlen("NOSUCHNAME"));
+
+                Py_DECREF(varbind);
+            }
             else
             {
                 py_log_msg(DEBUG, "netsnmp_get: bad varbind (%d)",
                            varlist_ind);
                 Py_XDECREF(varbind);
+            }
+
+            /*
+             * in v1 this will only advance if the varbind index is valid;
+             * in v2/v3 no_such_name is always set to 0.
+             */
+            if (!no_such_name)
+            {
+                vars = vars->next_variable;
             }
         }
 
@@ -1981,6 +2111,13 @@ static PyObject *netsnmp_get(PyObject *self, PyObject *args)
     }
 
 done:
+
+    /* the pointers will be equal if we didn't allocate additional space */
+    if (invalid_oids != snmpv1_invalid_oids)
+    {
+        printf("free bitarray\n");
+        bitarray_free(invalid_oids);
+    }
 
     SAFE_FREE(oid_arr);
     if (error)
@@ -2027,6 +2164,10 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
     char *tmpstr;
     Py_ssize_t tmplen;
     int error = 0;
+    unsigned long snmp_version = 0;
+
+    BITARRAY_DECLARE(snmpv1_invalid_oids, DEFAULT_NUM_BAD_OIDS);
+    bitarray *invalid_oids = snmpv1_invalid_oids;
 
     oid_arr = calloc(MAX_OID_LEN, sizeof(oid));
 
@@ -2038,6 +2179,8 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
         }
 
         ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+
+        snmp_version = py_netsnmp_attr_long(session, "version");
 
         if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
         {
@@ -2118,8 +2261,24 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
             }
         }
 
+        /* if we cannot represent the number of bad oids, we will need to resize. */
+        if (snmp_version == 1 && DEFAULT_NUM_BAD_OIDS < varlist_len)
+        {
+            invalid_oids = bitarray_calloc(varlist_len);
+
+            if (!invalid_oids)
+            {
+                error = 1;
+                snmp_free_pdu(pdu);
+                const char *err_msg = "failed to call bitarray_calloc";
+                PyErr_SetString(PyExc_RuntimeError, err_msg);
+                goto done;
+            }
+        }
+
         status = __send_sync_pdu(ss, pdu, &response, retry_nosuch, err_str,
-                                 &err_num, &err_ind);
+                                 &err_num, &err_ind, invalid_oids);
+
         __py_netsnmp_update_session_errors(session, err_str, err_num, err_ind);
         if (status != 0)
         {
@@ -2158,13 +2317,42 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
                                NETSNMP_OID_OUTPUT_NUMERIC);
         }
 
-        for (vars = (response ? response->variables : NULL), varlist_ind = 0;
-             vars && (varlist_ind < varlist_len);
-             vars = vars->next_variable, varlist_ind++)
+        /*
+         * In SNMPv1 we go through the response variables only if we know
+         * the varlist_ind is not set in the invalid_oids bit array.
+         * For bits that are set, we fix the input varbind so that it
+         * indicates NOSUCHNAME. For bits that are not set, we fill in the
+         * corresponding varbind and advance.
+         *
+         * In SNMPv2/v3 we simply fill the response variables against the
+         * original input Varbind list.
+         */
+        vars = (response ? response->variables : NULL);
+
+        for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
         {
+            int no_such_name = 0;
+
+            if (snmp_version == 1)
+            {
+                /* check if oid is invalid */
+                if (bitarray_test_bit(invalid_oids, varlist_ind))
+                {
+                    no_such_name = 1;
+                }
+            }
+            else if (!vars)
+            {
+                /*
+                 * no more varbinds to inspect
+                 * (this will only happen if no response is received from SNMP.
+                 */
+                break;
+            }
+
             varbind = PySequence_GetItem(varlist, varlist_ind);
 
-            if (PyObject_HasAttrString(varbind, "oid"))
+            if (!no_such_name && PyObject_HasAttrString(varbind, "oid"))
             {
                 *str_buf = '.';
                 *(str_buf + 1) = '\0';
@@ -2213,11 +2401,37 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
 
                 Py_DECREF(varbind);
             }
+            else if (no_such_name)
+            {
+                if (!PyObject_HasAttrString(varbind, "oid"))
+                {
+                    py_log_msg(DEBUG, "netsnmp_get: bad varbind (%d)",
+                               varlist_ind);
+                    Py_XDECREF(varbind);
+                }
+
+                py_netsnmp_attr_set_string(varbind, "snmp_type", "NOSUCHNAME",
+                                           strlen("NOSUCHNAME"));
+
+                py_netsnmp_attr_set_string(varbind, "value",
+                                           "NOSUCHNAME", strlen("NOSUCHNAME"));
+
+                Py_DECREF(varbind);
+            }
             else
             {
                 py_log_msg(DEBUG, "netsnmp_getnext: bad varbind (%d)",
                            varlist_ind);
                 Py_XDECREF(varbind);
+            }
+
+            /*
+             * in v1 this will only advance if the varbind index is valid;
+             * in v2/v3 no_such_name is always set to 0.
+             */
+            if (!no_such_name)
+            {
+                vars = vars->next_variable;
             }
         }
 
@@ -2233,6 +2447,13 @@ static PyObject *netsnmp_getnext(PyObject *self, PyObject *args)
     }
 
 done:
+
+    /* the pointers will be equal if we didn't allocate additional space */
+    if (invalid_oids != snmpv1_invalid_oids)
+    {
+        printf("free bitarray\n");
+        bitarray_free(invalid_oids);
+    }
 
     SAFE_FREE(oid_arr);
     if (error)
@@ -2475,7 +2696,7 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
 
         while (notdone) {
             status = __send_sync_pdu(ss, pdu, &response, retry_nosuch,
-                                     err_str, &err_num, &err_ind);
+                                     err_str, &err_num, &err_ind, NULL);
             __py_netsnmp_update_session_errors(session, err_str, err_num,
                                                err_ind);
             if (status != 0)
@@ -2776,7 +2997,7 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
             }
 
             status = __send_sync_pdu(ss, pdu, &response, retry_nosuch,
-                                     err_str, &err_num, &err_ind);
+                                     err_str, &err_num, &err_ind, NULL);
             __py_netsnmp_update_session_errors(session, err_str, err_num,
                                                err_ind);
             if (status != 0)
@@ -3080,7 +3301,7 @@ static PyObject *netsnmp_set(PyObject *self, PyObject *args)
         }
 
         status = __send_sync_pdu(ss, pdu, &response, NO_RETRY_NOSUCH,
-                                 err_str, &err_num, &err_ind);
+                                 err_str, &err_num, &err_ind, NULL);
         __py_netsnmp_update_session_errors(session, err_str, err_num, err_ind);
         if (status != 0)
         {

--- a/easysnmp/simple_bitarray.h
+++ b/easysnmp/simple_bitarray.h
@@ -139,11 +139,11 @@ static inline void bitarray_print_base16(bitarray *bitarray)
 
             for (j = 0; j < limb_size; j++)
             {
-                        /* mask the byte we want to print in hex */
-                        unsigned long mask = (0xFFUL) << (j * CHAR_BIT);
-                        c = (unsigned char) ((bitarray[i].limb & mask) >> (j * CHAR_BIT));
-                        printf("%02x", c);
-                    }
+                /* mask the byte we want to print in hex */
+                unsigned long mask = (0xFFUL) << (j * CHAR_BIT);
+                c = (unsigned char) ((bitarray[i].limb & mask) >> (j * CHAR_BIT));
+                printf("%02x", c);
+            }
 
             printf(" ");
         }

--- a/easysnmp/simple_bitarray.h
+++ b/easysnmp/simple_bitarray.h
@@ -1,0 +1,155 @@
+#ifndef SIMPLE_BITARRAY_H
+#define SIMPLE_BITARRAY_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+
+#if (__STDC_VERSION__ < 199901L)
+#define inline
+#endif
+
+typedef unsigned int bitarray_word;
+
+/*
+ * this is not guaranteed to be portable since an integral type size
+ * doesn't necessarily define the range
+ */
+#define BITARRAY_LIMB_BITS (sizeof(bitarray_word) * CHAR_BIT)
+
+/* macro to find the number of limbs to store num-bits */
+#define BITARRAY_NUM_BITS_TO_LIMBS(num_bits) \
+    (((num_bits) + BITARRAY_LIMB_BITS - 1) / BITARRAY_LIMB_BITS)
+
+/* fetch the limb containing bit position n */
+#define BITARRAY_LIMB(bitarray, n_bit) \
+    ((bitarray)[1 + ((n_bit) / BITARRAY_LIMB_BITS)].limb)
+
+/* build mask to select bit in limb */
+#define BITARRAY_LIMBBIT(n_bit) \
+    ((1UL << ((n_bit) % BITARRAY_LIMB_BITS)))
+
+/*
+ * we use a struct to give a name;
+ * when used, we reserve bitarray[0] for storing the number of bits.
+ */
+typedef struct
+{
+    bitarray_word limb;
+} bitarray;
+
+/*
+ * To declare a bitarray with automatic storage:
+ * {
+ *     BITARRAY_DECLARE(x, 1024); // 'x' will now be set to bitarray
+ * }
+ */
+#define BITARRAY_DECLARE(name, nbits) \
+    bitarray (name)[1 + BITARRAY_NUM_BITS_TO_LIMBS((nbits))] = { { nbits } }
+
+static inline size_t bitarray_num_limbs(bitarray *bitarray)
+{
+    return BITARRAY_NUM_BITS_TO_LIMBS(bitarray[0].limb);
+}
+
+static inline size_t bitarray_num_bits(bitarray *bitarray)
+{
+    return bitarray[0].limb;
+}
+
+static inline void bitarray_set_bit(bitarray *bitarray, bitarray_word n)
+{
+    BITARRAY_LIMB(bitarray, n) |= BITARRAY_LIMBBIT(n);
+}
+
+static inline void bitarray_clear_bit(bitarray *bitarray, bitarray_word n)
+{
+    BITARRAY_LIMB(bitarray, n) &= ~BITARRAY_LIMBBIT(n);
+}
+
+static inline void bitarray_change_bit(bitarray *bitarray, bitarray_word n)
+{
+    BITARRAY_LIMB(bitarray, n) ^= BITARRAY_LIMBBIT(n);
+}
+
+static inline int bitarray_test_bit(const bitarray *bitarray, bitarray_word n)
+{
+    return !!(BITARRAY_LIMB(bitarray, n) & BITARRAY_LIMBBIT(n));
+}
+
+static inline void bitarray_zero(bitarray *bitarray)
+{
+    memset(&bitarray[1], 0, bitarray_num_limbs(bitarray));
+}
+
+/*
+ * Allocation functions
+ */
+static inline bitarray *bitarray_alloc(unsigned long nbits)
+{
+        bitarray *ba = NULL;
+
+        size_t n_limbs = 1 + BITARRAY_NUM_BITS_TO_LIMBS(nbits);
+
+	ba = malloc(sizeof(bitarray) * n_limbs);
+        if (ba)
+        {
+            ba[0].limb = nbits;
+        }
+
+        return ba;
+}
+
+static inline bitarray *bitarray_calloc(unsigned long nbits)
+{
+        bitarray *ba = NULL;
+
+        size_t n_limbs = 1 + BITARRAY_NUM_BITS_TO_LIMBS(nbits);
+
+	ba = calloc(sizeof(bitarray), n_limbs);
+        if (ba)
+        {
+            ba[0].limb = nbits;
+        }
+
+	return ba;
+}
+
+static inline void bitarray_free(bitarray *bitarray)
+{
+    if (bitarray)
+    {
+        free(bitarray);
+    }
+}
+
+static inline void bitarray_print_base16(bitarray *bitarray)
+{
+    bitarray_word i;
+    size_t num_limbs = bitarray_num_limbs(bitarray);
+
+    printf("sizeof(limb)=%lu\n", sizeof(bitarray[0].limb));
+    printf("num_limbs=%lu\n", num_limbs);
+    for (i = 0; i <= num_limbs; i++)
+    {
+            unsigned char c;
+            unsigned int j;
+            size_t limb_size = sizeof(bitarray_word);
+
+            for (j = 0; j < limb_size; j++)
+            {
+                        /* mask the byte we want to print in hex */
+                        unsigned long mask = (0xFFUL) << (j * CHAR_BIT);
+                        c = (unsigned char) ((bitarray[i].limb & mask) >> (j * CHAR_BIT));
+                        printf("%02x", c);
+                    }
+
+            printf(" ");
+        }
+
+    printf("\n");
+}
+
+
+#endif

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.test import test as TestCommand
 # Determine if a base directory has been provided with the --basedir option
 in_tree = False
 # Add compiler flags if debug is set
-compile_args = []
+compile_args = ['-Wno-unused-function']
 for arg in sys.argv:
     if arg.startswith('--debug'):
         # Note from GCC manual:

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,15 @@ from setuptools.command.test import test as TestCommand
 
 # Determine if a base directory has been provided with the --basedir option
 in_tree = False
+# Add compiler flags if debug is set
+compile_args = []
 for arg in sys.argv:
-    if arg.startswith('--basedir='):
+    if arg.startswith('--debug'):
+        # Note from GCC manual:
+        #       If you use multiple -O options, with or without level numbers,
+        #       the last such option is the one that is effective.
+        compile_args.extend('-Wall -O0 -g'.split())
+    elif arg.startswith('--basedir='):
         basedir = arg.split('=')[1]
         sys.argv.remove(arg)
         in_tree = True
@@ -79,7 +86,8 @@ setup(
     ext_modules=[
         Extension(
             'easysnmp.interface', ['easysnmp/interface.c'],
-            library_dirs=libdirs, include_dirs=incdirs, libraries=libs
+            library_dirs=libdirs, include_dirs=incdirs, libraries=libs,
+            extra_compile_args=compile_args
         )
     ],
     classifiers=[

--- a/tests/test_easy.py
+++ b/tests/test_easy.py
@@ -119,9 +119,7 @@ def test_snmp_get_unknown(sess_args):
         snmp_get('sysDescripto.0', **sess_args)
 
 
-@pytest.mark.parametrize(
-    'sess_args', [sess_v1_args()]
-)
+@pytest.mark.parametrize('sess_args', [sess_v1_args()])
 def test_snmp_v1_get_with_retry_no_such(sess_args):
     sess_args['retry_no_such'] = True
 


### PR DESCRIPTION
When using `retry_no_such=True` for an easysnmp session, this ensures that the response is correclty aligned with the input variable list.