### PR TITLE
Brew library support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,18 @@ else:
     libdirs = [flag[2:] for flag in shlex.split(netsnmp_libs) if flag.startswith('-L')]  # noqa
     incdirs = []
 
+    if sys.platform == 'darwin': # OS X
+        brew = os.popen('brew info net-snmp').read()
+        if not 'command not found' in brew and not 'error' in brew:
+            # /usr/local/opt is the default brew `opt` prefix, however the user may have installed it elsewhere
+            # The `brew info <pkg>` includes an apostrophe, which breaks shlex. We'll simply replace it
+            libdirs = [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-L')]    # noqa
+            incdirs = [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-I')]    # noqa
+            # The homebrew version also depends on the Openssl keg
+            brew = os.popen('brew info openssl').read()
+            libdirs += [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-L')]    # noqa
+            incdirs += [flag[2:] for flag in shlex.split(brew.replace('\'','')) if flag.startswith('-I')]    # noqa
+
 
 # Setup the py.test class for use with the test command
 class PyTest(TestCommand):


### PR DESCRIPTION
Fix error where Net-SNMP is installed via Homebrew (5.7.x) but GCC
links to system-default libraries (5.6.x)