### PR TITLE
Added bulkwalk and tests; minor docstring edits

### DIFF
--- a/easysnmp/__init__.py
+++ b/easysnmp/__init__.py
@@ -1,6 +1,6 @@
 from .easy import (  # noqa
     snmp_get, snmp_set, snmp_set_multiple, snmp_get_next, snmp_get_bulk,
-    snmp_walk
+    snmp_walk, snmp_bulkwalk
 )
 from .exceptions import (  # noqa
     EasySNMPError, EasySNMPConnectionError, EasySNMPTimeoutError,

--- a/easysnmp/easy.py
+++ b/easysnmp/easy.py
@@ -78,7 +78,7 @@ def snmp_get_next(oids, **session_kargs):
     return session.get_next(oids)
 
 
-def snmp_get_bulk(oids, non_repeaters, max_repetitions, **session_kargs):
+def snmp_get_bulk(oids, non_repeaters=0, max_repetitions=10, **session_kargs):
     """
     Performs a bulk SNMP GET operation to retrieve multiple pieces of
     information in a single packet.
@@ -119,3 +119,29 @@ def snmp_walk(oids='.1.3.6.1.2.1', **session_kargs):
 
     session = Session(**session_kargs)
     return session.walk(oids)
+
+
+def snmp_bulkwalk(
+    oids='.1.3.6.1.2.1', non_repeaters=0, max_repetitions=10,
+    **session_kargs
+):
+    """
+    Uses SNMP GETBULK operation using the prepared session to
+    automatically retrieve multiple pieces of information in an OID
+
+    :param oids: you may pass in a single item
+                 * string representing the
+                 entire OID (e.g. 'sysDescr.0')
+                 * tuple (name, index) (e.g. ('sysDescr', 0))
+                 * list of OIDs
+    :param non_repeaters: the number of objects that are only expected to
+                          return a single GETNEXT instance, not multiple
+                          instances
+    :param max_repetitions: the number of objects that should be returned
+                            for all the repeating OIDs
+    :return: a list of SNMPVariable objects containing the values that
+             were retrieved via SNMP
+    """
+
+    session = Session(**session_kargs)
+    return session.bulkwalk(oids, non_repeaters, max_repetitions)

--- a/easysnmp/exceptions.py
+++ b/easysnmp/exceptions.py
@@ -17,7 +17,7 @@ class EasySNMPTimeoutError(EasySNMPConnectionError):
 
 
 class EasySNMPUnknownObjectIDError(EasySNMPError):
-    """Raised when an inexisted OID is requested."""
+    """Raised when a nonexistent OID is requested."""
     pass
 
 
@@ -32,7 +32,7 @@ class EasySNMPNoSuchNameError(EasySNMPError):
 class EasySNMPNoSuchObjectError(EasySNMPError):
     """
     Raised when an OID is requested which may have some form of existence but
-    an invalid object name.
+    is an invalid object name.
     """
     pass
 
@@ -46,6 +46,6 @@ class EasySNMPNoSuchInstanceError(EasySNMPError):
 
 class EasySNMPUndeterminedTypeError(EasySNMPError):
     """
-    Raised when the type cannot be determine when setting the value of an OID.
+    Raised when the type cannot be determined when setting the value of an OID.
     """
     pass

--- a/easysnmp/interface.c
+++ b/easysnmp/interface.c
@@ -2471,7 +2471,14 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
     netsnmp_session *ss;
     netsnmp_pdu *pdu, *response;
     netsnmp_pdu *newpdu;
-    netsnmp_variable_list *vars, *oldvars;
+    /*
+    Variable `oldvars` does not appear to fufill any immediate purpose and
+    causes segfaults in some cases, especially when running against OID '.1'
+    For legacy reasons, however, we will only leave it commented out, should
+    we find that it was only partially implemented or actually served a purpose
+    somewhere in the Net-SNMP library
+    */
+    netsnmp_variable_list *vars;//, *oldvars;
     struct tree *tp;
     int len;
     oid **oid_arr = NULL;
@@ -2710,11 +2717,11 @@ static PyObject *netsnmp_walk(PyObject *self, PyObject *args)
                 newpdu = snmp_pdu_create(SNMP_MSG_GETNEXT);
 
                 for (vars = (response ? response->variables : NULL),
-                     varlist_ind = 0,
-                     oldvars = (pdu ? pdu->variables : NULL);
+                     varlist_ind = 0; //,
+                     //oldvars = (pdu ? pdu->variables : NULL);
                      vars && (varlist_ind < varlist_len);
-                     vars = vars->next_variable, varlist_ind++,
-                     oldvars = (oldvars ? oldvars->next_variable : NULL))
+                     vars = vars->next_variable, varlist_ind++)//,
+                     //oldvars = (oldvars ? oldvars->next_variable : NULL))
                 {
                     if ((vars->name_length < oid_arr_len[varlist_ind]) ||
                         (memcmp(oid_arr[varlist_ind], vars->name,
@@ -2946,8 +2953,8 @@ static PyObject *netsnmp_getbulk(PyObject *self, PyObject *args)
 
             pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
 
-            pdu->errstat = nonrepeaters;
-            pdu->errindex = maxrepetitions;
+            pdu->non_repeaters = nonrepeaters;
+            pdu->max_repetitions = maxrepetitions;
 
             varbinds_iter = PyObject_GetIter(varbinds);
 
@@ -3151,11 +3158,429 @@ done:
     }
 }
 
-static PyObject *netsnmp_set(PyObject *self, PyObject *args)
+static PyObject *netsnmp_bulkwalk(PyObject *self, PyObject *args)
 {
+    int nonrepeaters;
+    int maxrepetitions;
     PyObject *session;
     PyObject *varlist;
+    PyObject *varlist_iter;
     PyObject *varbind;
+    PyObject *varbinds  = NULL;
+    int varlist_len = 0;
+    int varlist_ind;
+    netsnmp_session *ss;
+    netsnmp_pdu *pdu, *response;
+    netsnmp_variable_list *vars;
+    struct tree *tp;
+    int len;
+    oid **oid_arr = NULL;
+    int *oid_arr_len = NULL;
+    oid **oid_arr_broken_check = NULL;
+    int *oid_arr_broken_check_len = NULL;
+    int type;
+    char type_str[MAX_TYPE_NAME_LEN];
+    int status;
+    u_char str_buf[STR_BUF_SIZE];
+    u_char *str_bufp = str_buf;
+    size_t str_buf_len = sizeof(str_buf);
+    size_t out_len = 0;
+    int buf_over = 0;
+    char *tag;
+    char *iid = NULL;
+    int getlabel_flag = NO_FLAGS;
+    int sprintval_flag = USE_BASIC;
+    int old_format;
+    int best_guess;
+    int retry_nosuch;
+    int err_ind;
+    int err_num;
+    char err_str[STR_BUF_SIZE];
+    int notdone = 1;
+    char *tmpstr;
+    Py_ssize_t tmplen;
+    int error = 0;
+
+    py_log_msg(ERROR, "netsnmp_bulkwalk: Starting");
+    if (args)
+    {
+        if (!PyArg_ParseTuple(args, "OiiO", &session, &nonrepeaters,
+                              &maxrepetitions, &varlist))
+        {
+            goto done;
+        }
+
+        py_log_msg(ERROR, "netsnmp_bulkwalk: nonreps:%d max_reps:%d",
+          nonrepeaters, maxrepetitions);
+
+        if (!varlist)
+        {
+            goto done;
+        }
+
+        if ((varbinds = PyObject_GetAttrString(varlist, "varbinds")) == NULL)
+        {
+            goto done;
+        }
+        ss = (SnmpSession *)py_netsnmp_attr_void_ptr(session, "sess_ptr");
+
+        if (py_netsnmp_attr_string(session, "error_string", &tmpstr, &tmplen) < 0)
+        {
+            goto done;
+        }
+        memcpy(&err_str, tmpstr, tmplen);
+        err_num = py_netsnmp_attr_long(session, "error_number");
+        err_ind = py_netsnmp_attr_long(session, "error_index");
+
+        if (py_netsnmp_attr_long(session, "use_long_names"))
+        {
+            getlabel_flag |= USE_LONG_NAMES;
+        }
+        if (py_netsnmp_attr_long(session, "use_numeric"))
+        {
+            getlabel_flag |= USE_NUMERIC_OIDS;
+        }
+        if (py_netsnmp_attr_long(session, "use_enums"))
+        {
+            sprintval_flag = USE_ENUMS;
+        }
+        if (py_netsnmp_attr_long(session, "use_sprint_value"))
+        {
+            sprintval_flag = USE_SPRINT_VALUE;
+        }
+        best_guess = py_netsnmp_attr_long(session, "best_guess");
+        retry_nosuch = py_netsnmp_attr_long(session, "retry_no_such");
+
+        pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
+        pdu->non_repeaters = nonrepeaters;
+        pdu->max_repetitions = maxrepetitions;
+
+        /* we need an initial count for memory allocation */
+        varlist_iter = PyObject_GetIter(varlist);
+        varlist_len = 0;
+        while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
+        {
+            varlist_len++;
+        }
+        Py_DECREF(varlist_iter);
+
+        oid_arr_len              = calloc(varlist_len, sizeof(int));
+        oid_arr_broken_check_len = calloc(varlist_len, sizeof(int));
+
+        oid_arr                  = calloc(varlist_len, sizeof(oid *));
+        oid_arr_broken_check     = calloc(varlist_len, sizeof(oid *));
+
+        for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+        {
+            oid_arr[varlist_ind] = calloc(MAX_OID_LEN, sizeof(oid));
+            oid_arr_broken_check[varlist_ind] = calloc(MAX_OID_LEN,
+                                                       sizeof(oid));
+
+            oid_arr_len[varlist_ind]              = MAX_OID_LEN;
+            oid_arr_broken_check_len[varlist_ind] = MAX_OID_LEN;
+        }
+
+        /* get the initial starting oids */
+        varlist_iter = PyObject_GetIter(varlist);
+        varlist_ind = 0;
+        while (varlist_iter && (varbind = PyIter_Next(varlist_iter)))
+        {
+            if (py_netsnmp_attr_string(varbind, "oid", &tag, NULL) >= 0 &&
+                py_netsnmp_attr_string(varbind, "oid_index", &iid, NULL) >= 0)
+            {
+                tp = __tag2oid(tag, iid,
+                               oid_arr[varlist_ind], &oid_arr_len[varlist_ind],
+                               NULL, best_guess);
+            }
+            else
+            {
+                oid_arr_len[varlist_ind] = 0;
+            }
+
+            if (oid_arr_len[varlist_ind])
+            {
+                py_log_msg(ERROR, "netsnmp_bulkwalk: filling request: oid(%s) oid_idx(%s) oid_arr_len(%d) best_guess(%d)",
+                           tag, iid, oid_arr_len[varlist_ind], best_guess);
+
+                snmp_add_null_var(pdu, oid_arr[varlist_ind],
+                                  oid_arr_len[varlist_ind]);
+            }
+            else
+            {
+                PyErr_Format(EasySNMPUnknownObjectIDError,
+                             "unknown object id (%s)",
+                             (tag ? tag : "<null>"));
+                error = 1;
+                snmp_free_pdu(pdu);
+                Py_DECREF(varbind);
+                goto done;
+            }
+            /* release reference when done */
+            Py_DECREF(varbind);
+            varlist_ind++;
+        }
+
+        if (varlist_iter)
+        {
+            Py_DECREF(varlist_iter);
+        }
+
+        if (PyErr_Occurred())
+        {
+            error = 1;
+            snmp_free_pdu(pdu);
+            goto done;
+        }
+
+        /*
+        ** Set up for numeric or full OID's, if necessary.  Save the old
+        ** output format so that it can be restored when we finish -- this
+        ** is a library-wide global, and has to be set/restored for each
+        ** session.
+        */
+        old_format = netsnmp_ds_get_int(NETSNMP_DS_LIBRARY_ID,
+                                        NETSNMP_DS_LIB_OID_OUTPUT_FORMAT);
+
+        if (py_netsnmp_attr_long(session, "use_long_names"))
+        {
+            getlabel_flag |= USE_LONG_NAMES;
+
+            netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                               NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                               NETSNMP_OID_OUTPUT_FULL);
+        }
+
+        /* Setting use_numeric forces use_long_names on so check for
+           use_numeric after use_long_names (above) to make sure the final
+           outcome of NETSNMP_DS_LIB_OID_OUTPUT_FORMAT is
+           NETSNMP_OID_OUTPUT_NUMERIC */
+        if (py_netsnmp_attr_long(session, "use_numeric"))
+        {
+            getlabel_flag |= USE_LONG_NAMES;
+            getlabel_flag |= USE_NUMERIC_OIDS;
+
+            netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                               NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                               NETSNMP_OID_OUTPUT_NUMERIC);
+        }
+
+        /* delete the existing varbinds that we'll replace */
+        PySequence_DelSlice(varbinds, 0, PySequence_Length(varbinds));
+
+        if (PyErr_Occurred())
+        {
+            error = 1;
+            snmp_free_pdu(pdu);
+            goto done;
+        }
+
+        /* save the starting OID */
+        for (vars = pdu->variables, varlist_ind = 0;
+             vars != NULL;
+             vars = vars->next_variable, varlist_ind++)
+        {
+            oid_arr_broken_check[varlist_ind] =
+                calloc(MAX_OID_LEN, sizeof(oid));
+
+            oid_arr_broken_check_len[varlist_ind] = vars->name_length;
+            memcpy(oid_arr_broken_check[varlist_ind],
+                   vars->name, vars->name_length * sizeof(oid));
+            //py_log_msg(ERROR, "Saving starting OID: %s", oid_arr_broken_check[varlist_ind]);
+        }
+
+        for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+        {
+          notdone = 1;
+          while (notdone) {
+              py_log_msg(ERROR, "netsnmp_bulkwalk: Sending pdu req");
+              status = __send_sync_pdu(ss, pdu, &response, retry_nosuch,
+                                       err_str, &err_num, &err_ind, NULL);
+              __py_netsnmp_update_session_errors(session, err_str, err_num,
+                                                 err_ind);
+              if (status != 0)
+              {
+                  error = 1;
+                  goto done;
+              }
+
+              if (!response || !response->variables ||
+                  status != STAT_SUCCESS ||
+                  response->errstat != SNMP_ERR_NOERROR)
+              {
+                  notdone = 0;
+              }
+
+              if(notdone)
+              {
+                  vars = (response ? response->variables : NULL);
+                  while (vars)
+                  {
+                      if ((vars->name_length < oid_arr_len[varlist_ind]) ||
+                          (memcmp(oid_arr[varlist_ind], vars->name,
+                                  oid_arr_len[varlist_ind] * sizeof(oid)) != 0))
+                      {
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered end condition (next subtree iteration out of scope)");
+                          notdone = 0;
+                          break;
+                      }
+
+                      if ((vars->type == SNMP_ENDOFMIBVIEW) ||
+                          (vars->type == SNMP_NOSUCHOBJECT) ||
+                          (vars->type == SNMP_NOSUCHINSTANCE))
+                      {
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered end condition (ENDOFMIBVIEW, NOSUCHOBJECT, NO SUCH INSTANCE)");
+                          notdone = 0;
+                          break;
+                      }
+
+                      if (snmp_oid_compare(vars->name, vars->name_length,
+                                           oid_arr_broken_check[varlist_ind],
+                                           oid_arr_broken_check_len[varlist_ind]) <= 0)
+                      {
+                          /* The agent responded with an illegal response
+                             as the returning OID was lexogragically less
+                             then or equal to the requested OID...
+                             We need to give up here because an infite
+                             loop will result otherwise.
+
+                             XXX: this really should be an option to
+                             continue like the -Cc option to the snmpwalk
+                             application.
+                          */
+                          notdone = 0;
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: encountered oid_arr_broken_check condition");
+                          break;
+                      }
+
+                      varbind = py_netsnmp_construct_varbind();
+
+                      if (PyObject_HasAttrString(varbind, "oid"))
+                      {
+                          str_buf[0] = '.';
+                          str_buf[1] = '\0';
+                          out_len = 0;
+                          tp = netsnmp_sprint_realloc_objid_tree(&str_bufp,
+                                                                 &str_buf_len,
+                                                                 &out_len, 0,
+                                                                 &buf_over,
+                                                                 vars->name,
+                                                                 vars->name_length);
+                          str_buf[sizeof(str_buf) - 1] = '\0';
+
+                          type = __translate_asn_type(vars->type);
+
+                          if (__is_leaf(tp))
+                          {
+                              getlabel_flag &= ~NON_LEAF_NAME;
+                              py_log_msg(ERROR, "netsnmp_bulkwalk: is_leaf: %d", tp->type);
+                          }
+                          else
+                          {
+                              getlabel_flag |= NON_LEAF_NAME;
+                              py_log_msg(ERROR, "netsnmp_bulkwalk: !is_leaf: %d", tp->type);
+                          }
+
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: str_buf: %s", str_buf);
+
+                          __get_label_iid((char *) str_buf, &tag, &iid,
+                                          getlabel_flag);
+
+                          py_log_msg(ERROR,
+                                     "netsnmp_bulkwalk: filling response: %s:%s",
+                                     tag, iid);
+
+                          py_netsnmp_attr_set_string(varbind, "oid", tag,
+                                                     STRLEN(tag));
+                          py_netsnmp_attr_set_string(varbind, "oid_index", iid,
+                                                     STRLEN(iid));
+
+                          __get_type_str(type, type_str, 1);
+
+                          py_netsnmp_attr_set_string(varbind, "snmp_type",
+                                                     type_str, strlen(type_str));
+
+                          len = __snprint_value((char *) str_buf,
+                                                sizeof(str_buf), vars, tp,
+                                                type, sprintval_flag);
+                          str_buf[len] = '\0';
+
+                          py_netsnmp_attr_set_string(varbind, "value",
+                                                     (char *) str_buf, len);
+
+                          /* push the varbind onto the return varbinds */
+                          PyList_Append(varbinds, varbind);
+                      }
+                      else
+                      {
+                          py_log_msg(ERROR, "netsnmp_bulkwalk: bad varbind (%d)",
+                                     varlist_ind);
+                      }
+                      Py_XDECREF(varbind);
+
+                      memcpy(oid_arr_broken_check[varlist_ind], vars->name,
+                             sizeof(oid) * vars->name_length);
+                      oid_arr_broken_check_len[varlist_ind] = vars->name_length;
+
+                      // Create next request if we've reached the end
+                      if(vars->next_variable == NULL) {
+                        pdu = snmp_pdu_create(SNMP_MSG_GETBULK);
+                        pdu->non_repeaters = nonrepeaters;
+                        pdu->max_repetitions = maxrepetitions;
+                        snmp_add_null_var(pdu, vars->name, vars->name_length);
+                      }
+
+                      // Move on to next
+                      vars = vars->next_variable;
+                  }
+                  py_log_msg(ERROR, "netsnmp_bulkwalk: Finished reading all variables for req");
+              }
+
+              if (response)
+              {
+                  snmp_free_pdu(response);
+              }
+            }
+        }
+
+        /* Reset the library's behavior for numeric/symbolic OID's. */
+        netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID,
+                           NETSNMP_DS_LIB_OID_OUTPUT_FORMAT,
+                           old_format);
+
+
+        if (PyErr_Occurred())
+        {
+            error = 1;
+        }
+    }
+
+done:
+
+    Py_XDECREF(varbinds);
+    SAFE_FREE(oid_arr_len);
+    SAFE_FREE(oid_arr_broken_check_len);
+    for (varlist_ind = 0; varlist_ind < varlist_len; varlist_ind++)
+    {
+        SAFE_FREE(oid_arr[varlist_ind]);
+        SAFE_FREE(oid_arr_broken_check[varlist_ind]);
+    }
+    SAFE_FREE(oid_arr);
+    SAFE_FREE(oid_arr_broken_check);
+    if (error)
+    {
+        return NULL;
+    }
+    else
+    {
+        return Py_None;
+    }
+}
+
+static PyObject *netsnmp_set(PyObject *self, PyObject *args)
+{
+    PyObject *session = NULL;
+    PyObject *varlist = NULL;
+    PyObject *varbind = NULL;
     PyObject *ret = NULL;
     netsnmp_session *ss;
     netsnmp_pdu *pdu, *response;
@@ -3501,6 +3926,12 @@ static PyMethodDef interface_methods[] =
             netsnmp_walk,
             METH_VARARGS,
             "perform an SNMP WALK operation."
+        },
+        {
+            "bulkwalk",
+            netsnmp_bulkwalk,
+            METH_VARARGS,
+            "perform an SNMP BULKWALK operation."
         },
         {
             NULL,

--- a/easysnmp/session.py
+++ b/easysnmp/session.py
@@ -410,7 +410,7 @@ class Session(object):
         # Return a list or single item depending on what was passed in
         return list(varlist) if is_list else varlist[0]
 
-    def get_bulk(self, oids, non_repeaters, max_repetitions):
+    def get_bulk(self, oids, non_repeaters=0, max_repetitions=10):
         """
         Performs a bulk SNMP GET operation using the prepared session to
         retrieve multiple pieces of information in a single packet.
@@ -472,6 +472,37 @@ class Session(object):
 
         # Return a list of variables
         return list(varlist)
+
+    def bulkwalk(self, oids='.1.3.6.1.2.1', non_repeaters=0,
+                 max_repetitions=10):
+        """
+        Uses SNMP GETBULK operation using the prepared session to
+        automatically retrieve multiple pieces of information in an OID
+        :param oids: you may pass in a single item (multiple values currently
+                     experimental) which may be a string representing the
+                     entire OID (e.g. 'sysDescr.0') or may be a tuple
+                     containing the name as its first item and index as its
+                     second (e.g. ('sysDescr', 0))
+        :return: a list of SNMPVariable objects containing the values that
+                 were retrieved via SNMP
+        """
+
+        if self.version == 1:
+            raise EasySNMPError(
+                "BULKWALK is not available for SNMP version 1")
+
+        # Build our variable bindings for the C interface
+        varlist, _ = build_varlist(oids)
+
+        # Perform the SNMP walk using GETNEXT operations
+        interface.bulkwalk(self, non_repeaters, max_repetitions, varlist)
+
+        # Validate the variable list returned
+        if self.abort_on_nonexistent:
+            validate_results(varlist)
+
+        # Return a list of variables
+        return varlist
 
     def __del__(self):
         """Deletes the session and frees up memory."""

--- a/tests/test_easy.py
+++ b/tests/test_easy.py
@@ -5,7 +5,7 @@ import platform
 import pytest
 from easysnmp.easy import (
     snmp_get, snmp_set, snmp_set_multiple, snmp_get_next, snmp_get_bulk,
-    snmp_walk
+    snmp_walk, snmp_bulkwalk
 )
 from easysnmp.exceptions import (
     EasySNMPError, EasySNMPUnknownObjectIDError, EasySNMPNoSuchObjectError,
@@ -498,6 +498,39 @@ def test_snmp_walk_res(sess_args):
     assert res[5].oid_index == '0'
     assert res[5].value == 'my original location'
     assert res[5].snmp_type == 'OCTETSTR'
+
+
+@pytest.mark.parametrize(
+    'sess_args', [sess_v1_args(), sess_v2_args(), sess_v3_args()]
+)
+def test_snmp_bulkwalk_res(sess_args):
+    if sess_args['version'] == 1:
+        with pytest.raises(EasySNMPError):
+            snmp_bulkwalk('system', **sess_args)
+    else:
+        res = snmp_bulkwalk('system', **sess_args)
+
+        assert len(res) >= 7
+
+        assert res[0].oid == 'sysDescr'
+        assert res[0].oid_index == '0'
+        assert platform.version() in res[0].value
+        assert res[0].snmp_type == 'OCTETSTR'
+
+        assert res[3].oid == 'sysContact'
+        assert res[3].oid_index == '0'
+        assert res[3].value == 'G. S. Marzot <gmarzot@marzot.net>'
+        assert res[3].snmp_type == 'OCTETSTR'
+
+        assert res[4].oid == 'sysName'
+        assert res[4].oid_index == '0'
+        assert res[4].value == platform.node()
+        assert res[4].snmp_type == 'OCTETSTR'
+
+        assert res[5].oid == 'sysLocation'
+        assert res[5].oid_index == '0'
+        assert res[5].value == 'my original location'
+        assert res[5].snmp_type == 'OCTETSTR'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -335,6 +335,37 @@ def test_session_walk(sess):
 
 
 @pytest.mark.parametrize('sess', [sess_v1(), sess_v2(), sess_v3()])
+def test_session_bulkwalk(sess):
+    if sess.version == 1:
+        with pytest.raises(EasySNMPError):
+            sess.bulkwalk('system')
+    else:
+        res = sess.walk('system')
+
+        assert len(res) >= 7
+
+        assert res[0].oid == 'sysDescr'
+        assert res[0].oid_index == '0'
+        assert platform.version() in res[0].value
+        assert res[0].snmp_type == 'OCTETSTR'
+
+        assert res[3].oid == 'sysContact'
+        assert res[3].oid_index == '0'
+        assert res[3].value == 'G. S. Marzot <gmarzot@marzot.net>'
+        assert res[3].snmp_type == 'OCTETSTR'
+
+        assert res[4].oid == 'sysName'
+        assert res[4].oid_index == '0'
+        assert res[4].value == platform.node()
+        assert res[4].snmp_type == 'OCTETSTR'
+
+        assert res[5].oid == 'sysLocation'
+        assert res[5].oid_index == '0'
+        assert res[5].value == 'my original location'
+        assert res[5].snmp_type == 'OCTETSTR'
+
+
+@pytest.mark.parametrize('sess', [sess_v1(), sess_v2(), sess_v3()])
 def test_session_walk_all(sess):
     # TODO: Determine why walking iso doesn't work for SNMP v1
     if sess.version == 1:


### PR DESCRIPTION
`Bulkwalk` has been benchmarked against `walk` and performs exceptionally well, at least with v2(c). I have not yet been able to complete tests for v3 but can do so if desired.

The following tests were performed locally on a Cisco C3750 running IOS C3750-IPBASEK9-M, Version 12.2(55)SE1, with SNMPv2. Each were given the following args:
 * Retries - 1
 * Timeout - 5 seconds
 * OID - `.1`

|  | Net-SNMP `snmpbulkwalk` | Easysnmp `session.bulkwalk` | Net-SNMP `snmpwalk` | Easysnmp `session.walk` |
|---|------------------------------------|-----------------------------|-----------------------------|------------------------|
| Time elapsed | 1m 21.258s | 1m 21.474s | 2m 14.405s | 2m 14.594s |
| OIDs returned | 33866 | 31788 - 31998 | 33864 | 31788 - 31998 |

Both of Easysnmp's functions appear to be missing ~2,000 OID values in comparison to those found from Net-SNMP's and are inconsistent between test. The quantity of OIDs returned (the size of the list) differs by less than 5 each time the script is run, which may mean that this is caused when loading MIBs at runtime. It should be noted that this is also seen in the library prior to any changes made in this commit. I will be investigating this in the future to see why it is happening. Perhaps it's related to the same reason that `walk` cannot be passed `'.'` as the OID argument.

Memory leaks were also tested between both `bulkwalk` and `walk`. Prior to the removal of `oldvars` in the interface.c file, `walk` was reported to have "possibly lost" ~1MB of memory during this test by Valgrind. However, `walk` would encounter a segfault irregularly and a gdb session pointed towards this variable. It did not appear to actually be used by any significant part of the function; removing it does not reveal any impact on data returned. After removing it, Valgrind only reports a loss of ~505KB, only ~4KB more than `bulkwalk`. I am not sure if this variable actually does anything to move the function forward, so I have commented it out for now.

On the subject of memory leaks, measurements of "free memory" by `top` for both `walk` and `bulkwalk` indicate that memory _seems_ to be released properly back to the system. The values Valgrind reports as various categories of "lost memory" do not appear completely accurate and may just be due to Python not yet having completed a garbage collect when the script completes. `heapy` reports less than 540 bytes in use after deleting each `session` object,  however `heapy` seems to be limited in scope to only the Python instance and not the actual system. I have not tried `smem` as I did in #21 but I can run tests if desired.

And do forgive my edits on the docstrings: I was just trying to get the tests to pass :smile: 