### PR TITLE
Don't hardcode gcc compiler flags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.test import test as TestCommand
 # Determine if a base directory has been provided with the --basedir option
 in_tree = False
 # Add compiler flags if debug is set
-compile_args = ['-Wno-unused-function']
+compile_args = []
 for arg in sys.argv:
     if arg.startswith('--debug'):
         # Note from GCC manual:


### PR DESCRIPTION
I would ask that you please do not hardcode gcc-specific compiler flags
